### PR TITLE
Disable docgen temporarily

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -55,13 +55,13 @@ jobs:
         run: |
           ./build_all.sh
 
-      - name: Compile blueprint and documentation
-        uses: leanprover-community/docgen-action@deed0cdc44dd8e5de07a300773eb751d33e32fc8 # 2025-10-26
-        with:
-          homepage: home_page
-          blueprint: true
-          build-page: false
-          deploy: false
+      # - name: Compile blueprint and documentation
+      #   uses: leanprover-community/docgen-action@deed0cdc44dd8e5de07a300773eb751d33e32fc8 # 2025-10-26
+      #   with:
+      #     homepage: home_page
+      #     blueprint: true
+      #     build-page: false
+      #     deploy: false
 
       - name: "Upload website (API documentation, blueprint and any home page)"
         if: github.event_name == 'push'


### PR DESCRIPTION
I want to test the deployment of the website in CI, but docgen takes 2 hours so that's impractical. I'll enable it again afterwards.